### PR TITLE
lf - payment types list returning all items

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -86,12 +86,8 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
-
-        customer_id = self.request.query_params.get("customer", None)
-
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        customer = Customer.objects.get(user=request.auth.user)
+        payment_types = Payment.objects.filter(customer=customer)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={"request": request}


### PR DESCRIPTION
The GET paymenttypes request was returning all payments types in the database. Issue was corrected by filtering the payments to only the authenticated user's payments.

## Changes

- views/paymenttype.py: list function - get authenticated user from request and retrieve the corresponding Customer, filter payment types by the Customer


## Requests / Responses

**Request**

GET get all payment types
using the Authorization `Token 9ba45f09651c5b0c404f37a2d2572c026c146690`

**Response**
HTTP/1.1 201 OK
Returns empty array (user does not have any payment types saved

--

**Request**
GET get all payment types
using Authorization `Token 9ba45f09651c5b0c404f37a2d2572c026c146688`

**Response**
```
[
  {
    "id": 2,
    "url": "http://localhost:8000/paymenttypes/2",
    "merchant_name": "Mastercard",
    "account_number": "39j3984fj9sofi9",
    "expiration_date": "2020-02-01",
    "create_date": "2019-12-12"
  }
]
```

## Testing

Description of how to test code...

- [ ] Run `./seed_data.sh` to reseed database
- [ ] start the debugger
- [ ] Run Get all payment types in Yaak
- [ ] Run Get all payment types in Yaak with a different auth token


## Related Issues

- Fixes #10 
