### PR TITLE
LF - Payment type date incorrect

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -41,8 +41,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
When adding a new payment type, the creation date and expiration date of the payment type were being swapped.

A correction was made to the create function in `views/paymenttype.py` to point the correct request data point to the corresponding object attribute. 

## Changes

- line 44-45: 
```
new_payment.expiration_date = request.data["expiration_date"]
new_payment.create_date = request.data["create_date"]
```

## Requests / Responses
Make sure the expiration date in the request matches the expiration 
**Request**

POST Create a payment type
(Maintain the given Authorization and JSON body)

```json
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 Created

```json
{
  "id": 7,
  "url": "http://localhost:8000/paymenttypes/7",
  "merchant_name": "Amex",
  "account_number": "000000000000",
  "expiration_date": "2023-12-12",
  "create_date": "2020-12-12"
}
```

## Testing

Description of how to test code...

- [ ]  Run `./seed_data.sh` in your terminal to reseed database
- [ ] Start the debugger
- [ ] Run the `POST Create a payment type` request in Yaak


## Related Issues

- Fixes: #9 