### PR TITLE
Ea bug#8

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -180,17 +180,13 @@ class Profile(ViewSet):
             """
             try:
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={"request": request}
-                )
 
                 cart = {}
                 cart["order"] = OrderSerializer(
                     open_order, many=False, context={"request": request}
                 ).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
+                cart["order"]["size"] = len(cart["order"]["lineitems"])
+
 
             except Order.DoesNotExist as ex:
                 return Response(


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes
THIS IS FOR TICKET #3

Ticket 3 bug removed. Line items were being serialized twice. I removed the second manual serialization from profile.py in the cart method. 


## Requests / Responses

**Request**

POST `/profile/cart` Adds item to cart

```json
{
    "product_id:" n 
}
```

**Response**

HTTP 200 OK

```json
{
  "id": 17,
  "product": {
    "id": 34,
    "name": "Golf",
    "price": 653.59,
    "number_sold": 0,
    "description": "1994 Volkswagen",
    "quantity": 4,
    "created_date": "2019-07-10",
    "location": "Berlin",
    "image_path": "http://localhost:8000/media/products/vehicle.png",
    "average_rating": 0
}

## Testing
CHECK CART

GET `/profile/cart` Gets cart check for no duplicated item. 




Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

-Fixes #3 