### PR TITLE
Mf test order

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -1,22 +1,28 @@
+import datetime
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 
 class OrderTests(APITestCase):
+
+    # Add any fixtures you want to run to build the test database
+    fixtures = ['users', 'tokens', 'productrating', 'product', 'product_category', 'payment', 'order', 'order_product', 'favoritesellers', 'customers' ]
+
+
     def setUp(self) -> None:
         """
         Create a new account and create sample category
         """
         url = "/register"
         data = {
-            "username": "steve",
+            "username": "test",
             "password": "Admin8*",
-            "email": "steve@stevebrownlee.com",
+            "email": "test@test.com",
             "address": "100 Infinity Way",
             "phone_number": "555-1212",
-            "first_name": "Steve",
-            "last_name": "Brownlee",
+            "first_name": "Test",
+            "last_name": "Testy",
         }
         response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
@@ -62,7 +68,6 @@ class OrderTests(APITestCase):
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(json_response["id"], 1)
         self.assertEqual(json_response["size"], 1)
         self.assertEqual(len(json_response["lineitems"]), 1)
 
@@ -92,5 +97,81 @@ class OrderTests(APITestCase):
         self.assertEqual(len(json_response["lineitems"]), 0)
 
     # TODO: Complete order by adding payment type
+    def test_add_payment_type(self):
+        """
+        Ensure we can add a product to an order.
+        """
+        # Add payment to order
+        url = "/paymenttypes"
+        data = {"payment_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get payment and verify payment was added
+        url = "/paymenttypes"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 1)
+    
 
     # TODO: New line item is not added to closed order
+    def test_add_product_to_closed_order(self):
+        # Step 1: Create a payment type
+        url = "/paymenttypes"
+        data = {
+        "merchant_name": "American Express",
+        "account_number": "111-1111-1111",
+        "expiration_date": "2024-12-31",
+        "create_date": datetime.date.today(),
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+        json_response = json.loads(response.content)
+        payment_id = json_response["id"]
+
+        # Step 2: Add a product to the cart (creates an open order)
+        self.test_add_product_to_order()
+
+        # Step 3: Get the cart and save the order id
+        url = "/cart"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+        closed_order_id = json_response["id"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["size"], 1)
+        self.assertEqual(len(json_response["lineitems"]), 1)
+
+        # Step 4: Close the order by adding a payment type
+        url = f"/orders/{closed_order_id}"
+        data = {"payment_type": payment_id}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.put(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Step 5: Add another product to the cart
+        url = "/cart"
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+
+        # Step 6: Get the cart again
+        url = "/cart"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+
+        # Step 7: Assert the new cart is a different order
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotEqual(json_response["id"], closed_order_id)
+        self.assertEqual(json_response["size"], 1)
+    
+        # Step 8: Assert the new cart only has 1 item
+        self.assertEqual(len(json_response["lineitems"]), 1)

--- a/tests/order.py
+++ b/tests/order.py
@@ -7,8 +7,18 @@ from rest_framework.test import APITestCase
 class OrderTests(APITestCase):
 
     # Add any fixtures you want to run to build the test database
-    fixtures = ['users', 'tokens', 'productrating', 'product', 'product_category', 'payment', 'order', 'order_product', 'favoritesellers', 'customers' ]
-
+    fixtures = [
+        "users",
+        "tokens",
+        "productrating",
+        "product",
+        "product_category",
+        "payment",
+        "order",
+        "order_product",
+        "favoritesellers",
+        "customers",
+    ]
 
     def setUp(self) -> None:
         """
@@ -103,7 +113,12 @@ class OrderTests(APITestCase):
         """
         # Add payment to order
         url = "/paymenttypes"
-        data = {"payment_id": 1}
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today(),
+        }
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.post(url, data, format="json")
 
@@ -117,17 +132,16 @@ class OrderTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["id"], 1)
-    
 
     # TODO: New line item is not added to closed order
     def test_add_product_to_closed_order(self):
         # Step 1: Create a payment type
         url = "/paymenttypes"
         data = {
-        "merchant_name": "American Express",
-        "account_number": "111-1111-1111",
-        "expiration_date": "2024-12-31",
-        "create_date": datetime.date.today(),
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today(),
         }
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
@@ -172,6 +186,6 @@ class OrderTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotEqual(json_response["id"], closed_order_id)
         self.assertEqual(json_response["size"], 1)
-    
+
         # Step 8: Assert the new cart only has 1 item
         self.assertEqual(len(json_response["lineitems"]), 1)

--- a/tests/order.py
+++ b/tests/order.py
@@ -122,10 +122,10 @@ class OrderTests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.post(url, data, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Get payment and verify payment was added
-        url = "/paymenttypes"
+        url = "/paymenttypes/1"
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -28,7 +28,7 @@ class PaymentTests(APITestCase):
         """
         Ensure we can add a payment type for a customer.
         """
-        # Add product to order
+        # Add payment to order
         url = "/paymenttypes"
         data = {
             "merchant_name": "American Express",


### PR DESCRIPTION
Create a new test in the tests/order.py module that verifies that adding a product to the user's cart adds it to an open order, and not a closed one.

## Changes

- created test to make sure a product can't be added to a closed order

## Requests / Responses

**Response**

System check identified no issues (0 silenced).
test_add_payment_type (tests.order.OrderTests)
Ensure we can add a product to an order. ... ok
test_add_product_to_closed_order (tests.order.OrderTests) ... ok
test_add_product_to_order (tests.order.OrderTests)
Ensure we can add a product to an order. ... ok
test_remove_product_from_order (tests.order.OrderTests)
Ensure we can remove a product from an order. ... ok

----------------------------------------------------------------------
Ran 4 tests in 1.103s

OK

## Testing

Description of how to test code...

- [ ] switch to mf-test-order branch
- [ ] Run "python manage.py test tests.order.OrderTests -v 2"


## Related Issues

- Fixes #19
- Fixes #18