### PR TITLE
Feature: Increase maximum possible price

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -18,7 +18,7 @@ class Product(SafeDeleteModel):
         Customer, on_delete=models.DO_NOTHING, related_name="products"
     )
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],
     )
     description = models.CharField(
         max_length=255,

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -39,6 +39,7 @@ class Product(SafeDeleteModel):
         width_field=None,
         max_length=None,
         null=True,
+        blank=True,
     )
 
     @property

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -1,7 +1,6 @@
 """View module for handling requests about products"""
 
 from urllib import request
-
 from django.core.exceptions import ValidationError
 from rest_framework.decorators import action
 from bangazonapi.models.recommendation import Recommendation

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -2,6 +2,7 @@
 
 from urllib import request
 
+from django.core.exceptions import ValidationError
 from rest_framework.decorators import action
 from bangazonapi.models.recommendation import Recommendation
 import base64
@@ -122,6 +123,11 @@ class Products(ViewSet):
             )
 
             new_product.image_path = data
+
+        try:
+            new_product.full_clean()
+        except ValidationError as ex:
+            return Response({"message": ex.message_dict}, status=status.HTTP_400_BAD_REQUEST)
 
         new_product.save()
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -41,7 +41,7 @@ class ProductTests(APITestCase):
         url = "/products"
         data = {
             "name": "Kite",
-            "price": 14.99,
+            "price": 17500.00,
             "quantity": 60,
             "description": "It flies high",
             "category_id": 1,
@@ -53,7 +53,7 @@ class ProductTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(json_response["name"], "Kite")
-        self.assertEqual(json_response["price"], 14.99)
+        self.assertEqual(json_response["price"], 17500.00)
         self.assertEqual(json_response["quantity"], 60)
         self.assertEqual(json_response["description"], "It flies high")
         self.assertEqual(json_response["location"], "Pittsburgh")


### PR DESCRIPTION
The system currently will reject any product being created with a price greater than $10,000. Increase that maximum to $17,500.

## Changes

- Changed MaxValueValidator in model/product.py from 10000.00 to 17500.00
- Since Min/MaxValueValidator is used, added try block in views/product.py to enforce validation in view.  Validator will ONLY run if .full_clean() is called.
- Changed price from 10000.00 to 17500.00 in tests/product.py test_create_product to test changes made

## Requests / Responses

**Request**

POST `/products` Creates a new product
```
{
	"name": "Kite",
	"price": 17500.00,
	"quantity": 60,
	"description": "It flies high",
	"category_id": 6,
	"location": "Pittsburgh",
	"image_path": "data:image ...
}
```

**Response**

HTTP/1.1 201 Created
```
{
  "id": 152,
  "name": "Kite",
  "price": 17500.0,
  "number_sold": 0,
  "description": "It flies high",
  "quantity": 60,
  "created_date": "2026-04-21",
  "location": "Pittsburgh",
  "image_path": "http://localhost:8000/media/products/None-Kite_Ety1F4w.jpeg",
  "average_rating": 0
}
```
## Testing

Description of how to test code...

- [ ] Run ```./seed_data.sh```
- [ ] Run ```python manage.py test tests.product.ProductTests -v 2``` Test again by changing price to 17501.00 to see if validation catches it.
- [ ]  Check/Run POST Create product (JSON body), changing price from 10000.00 to 17500.00 in your api tester of choice (Yaak/Bruno). Test again by changing price to 17501.00 to see if validation catches it.


## Related Issues

- Fixes #14 