### PR TITLE
Bug: Incorrect result for minimum products sold

### DIFF
--- a/bangazonapi/fixtures/order_product.json
+++ b/bangazonapi/fixtures/order_product.json
@@ -25,7 +25,7 @@
   },
   {
     "model": "bangazonapi.orderproduct",
-    "pk": 7,
+    "pk": 10,
     "fields": {
       "order_id": 8,
       "product_id": 5

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -293,7 +293,7 @@ class Products(ViewSet):
         if number_sold is not None:
 
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Clients can request a list of products that have sold at least the specified number of items using the following URL scheme.

http://localhost:8000/products?number_sold=2

This should return products that have been sold 2+ times. 

## Changes

- In `views/product.py` changed, on line 296, operator from <= to >= since we want to check if a product has been sold more than twice instead of less than
- In `fixtures/order_product.json` there were two objects with pk 7. Changed first one to 10. 

## Requests / Responses

Ticket says more than 20 but we do not have that many products sold so keep imported request of 2 the same. 

**Request**

GET `http://localhost:8000/products?number_sold=2` 

**Response**

HTTP/1.1 200 OK

```[
  {
    "id": 50,
    "name": "Golf",
    "price": 653.59,
    "number_sold": 2,
    "description": "1994 Volkswagen",
    "quantity": 4,
    "created_date": "2019-07-10",
    "location": "Berlin",
    "image_path": "http://localhost:8000/media/products/vehicle.png",
    "average_rating": 3.25
  }
]```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run Products/GET Products that have sold 2 or more


## Related Issues

- Fixes #7