### PR TITLE
29 - Recommend products to user profile

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -309,13 +309,18 @@ class Products(ViewSet):
         """Recommend products to other users"""
 
         if request.method == "POST":
-            rec = Recommendation()
-            rec.recommender = Customer.objects.get(user=request.auth.user)
-            rec.customer = Customer.objects.get(user__username=request.data["username"])
-            rec.product = Product.objects.get(pk=pk)
+            try:
+                rec = Recommendation()
+                rec.recommender = Customer.objects.get(user=request.auth.user)
+                rec.customer = Customer.objects.get(
+                    user__username=request.data["username"]
+                )
+                rec.product = Product.objects.get(pk=pk)
 
-            rec.save()
+                rec.save()
 
-            return Response(None, status=status.HTTP_204_NO_CONTENT)
+                return Response(None, status=status.HTTP_204_NO_CONTENT)
+            except Customer.DoesNotExist as ex:
+                return Response(None, status=status.HTTP_404_NOT_FOUND)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -311,7 +311,7 @@ class Products(ViewSet):
         if request.method == "POST":
             rec = Recommendation()
             rec.recommender = Customer.objects.get(user=request.auth.user)
-            rec.customer = Customer.objects.get(user__id=request.data["recipient"])
+            rec.customer = Customer.objects.get(user__username=request.data["username"])
             rec.product = Product.objects.get(pk=pk)
 
             rec.save()

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -64,13 +64,29 @@ class Profile(ViewSet):
                         "customer": "http://localhost:8000/customers/7"
                     }
                 ],
-                "recommends": [
+                "user_recommends": [
                     {
                         "product": {
                             "id": 32,
                             "name": "DB9"
                         },
                         "customer": {
+                            "id": 5,
+                            "user": {
+                                "first_name": "Joe",
+                                "last_name": "Shepherd",
+                                "email": "joe@joeshepherd.com"
+                            }
+                        }
+                    }
+                ],
+                "recommended_to_user": [
+                    {
+                        "product": {
+                            "id": 32,
+                            "name": "DB9"
+                        },
+                        "recommender": {
                             "id": 5,
                             "user": {
                                 "first_name": "Joe",
@@ -86,6 +102,9 @@ class Profile(ViewSet):
             current_user = Customer.objects.get(user=request.auth.user)
             current_user.user_recommends = Recommendation.objects.filter(
                 recommender=current_user
+            )
+            current_user.recommended_to_user = Recommendation.objects.filter(
+                customer=current_user
             )
 
             serializer = ProfileSerializer(
@@ -369,7 +388,7 @@ class ProfileProductSerializer(serializers.ModelSerializer):
 
 
 class RecommenderSerializer(serializers.ModelSerializer):
-    """JSON serializer for recommendations"""
+    """JSON serializer for recommendations by current user"""
 
     customer = CustomerSerializer()
     product = ProfileProductSerializer()
@@ -382,6 +401,20 @@ class RecommenderSerializer(serializers.ModelSerializer):
         )
 
 
+class RecommendedSerializer(serializers.ModelSerializer):
+    """JSON serializer for recommendations for current user"""
+
+    recommender = CustomerSerializer()
+    product = ProfileProductSerializer()
+
+    class Meta:
+        model = Recommendation
+        fields = (
+            "product",
+            "recommender",
+        )
+
+
 class ProfileSerializer(serializers.ModelSerializer):
     """JSON serializer for customer profile
 
@@ -391,6 +424,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     user = UserSerializer(many=False)
     user_recommends = RecommenderSerializer(many=True)
+    recommended_to_user = RecommendedSerializer(many=True)
 
     class Meta:
         model = Customer
@@ -401,7 +435,8 @@ class ProfileSerializer(serializers.ModelSerializer):
             "phone_number",
             "address",
             "payment_types",
-            "user_recommends"
+            "user_recommends",
+            "recommended_to_user",
         )
         depth = 1
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -84,7 +84,9 @@ class Profile(ViewSet):
         """
         try:
             current_user = Customer.objects.get(user=request.auth.user)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            current_user.user_recommends = Recommendation.objects.filter(
+                recommender=current_user
+            )
 
             serializer = ProfileSerializer(
                 current_user, many=False, context={"request": request}
@@ -186,7 +188,6 @@ class Profile(ViewSet):
                     open_order, many=False, context={"request": request}
                 ).data
                 cart["order"]["size"] = len(cart["order"]["lineitems"])
-
 
             except Order.DoesNotExist as ex:
                 return Response(
@@ -389,7 +390,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     """
 
     user = UserSerializer(many=False)
-    recommends = RecommenderSerializer(many=True)
+    user_recommends = RecommenderSerializer(many=True)
 
     class Meta:
         model = Customer
@@ -400,7 +401,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "phone_number",
             "address",
             "payment_types",
-            "recommends",
+            "user_recommends"
         )
         depth = 1
 


### PR DESCRIPTION
Product recommendations now appear on a users profile.
Users are able to send and receive product recommendations. These products will appear on an users profile page.

## Changes

- Created new Recommendation Serializer for the recs received from other users
- Updated Profile Serializer to include new Rec Serialization
- Updated list function in profile to include both types of recommendations

## Requests / Responses

**Request**

GET `/profile` Gets user profile

Use any auth token (using Steve for example)

**Response**

HTTP/1.1 200 OK

```json
{
  "id": 4,
  "url": "http://localhost:8000/customers/4",
  "user": {
    "first_name": "Steve",
    "last_name": "Brownlee",
    "email": "steve@stevebrownlee.com"
  },
  "phone_number": "555-1212",
  "address": "100 Infinity Way",
  "payment_types": [],
  "user_recommends": [],
  "recommended_to_user": []
}
```
Should return object with "user_recommends" and "recommended_to_user" properties
## Testing

 - [ ]  Run ./seed_data.sh in your terminal to reseed database
 - [ ]  Start the debugger
 - [ ]  Run the GET User Profile api request


## Related Issues

- Fixes #29 
