### PR TITLE
 Feature: Get products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -279,6 +279,8 @@ class Products(ViewSet):
         order = self.request.query_params.get("order_by", None)
         direction = self.request.query_params.get("direction", None)
         number_sold = self.request.query_params.get("number_sold", None)
+        # Support filtering by location 
+        location = self.request.query_params.get("location", None)
 
         if order is not None:
             order_filter = order
@@ -303,6 +305,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if location is not None:
+            products = products.filter(location__icontains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={"request": request}


### PR DESCRIPTION
When the client performs a GET request to the products resource, a query string parameter of location should be supported to get all products whose location property contains the value of the query string parameter.

## Changes

- added query param logic for location
- added filter logic for location by using _icontains to capture the city regardless of capitalization or not

## Requests / Responses

**Request**

GET `/products?location=Paris` Finds all products available in Paris

**Response**

HTTP/1.1 200 OK

```json
[
  {
    "id": 2,
    "name": "Golf",
    "price": 653.59,
    "number_sold": 0,
    "description": "1994 Volkswagen",
    "quantity": 4,
    "created_date": "2019-07-10",
    "location": "Paris",
    "image_path": "http://localhost:8000/media/products/vehicle.png",
    "average_rating": 0
  }, ...
```

## Testing

Description of how to test code...

- [ ] restart debugger
- [ ] Create new fetch call in Bruno/Yaak GET all products by location (you can right click on GET all products and clone then rename)
- [ ] change params to `/products?location=Paris` 
- [ ] change city to one of the following and test to make sure it works for other cities: Seoul, Paris, Vienna, New York, Moscow, Berlin, Toronto, London, Tokyo, Dubai, Sydney, Workshop
- [ ] Test on client side with filter bar 


## Related Issues

- Fixes #15