### PR TITLE
completed order and listed orders

### DIFF
--- a/bangazonapi/models/order.py
+++ b/bangazonapi/models/order.py
@@ -11,6 +11,5 @@ class Order(models.Model):
         on_delete=models.DO_NOTHING,
     )
     payment_type = models.ForeignKey(Payment, on_delete=models.DO_NOTHING, null=True)
-    created_date = models.DateField(
-        default="0000-00-00",
-    )
+    created_date = models.DateField(auto_now_add=True)
+    completed_on = models.DateField(null=True, blank=True)

--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -30,7 +30,6 @@ class Cart(ViewSet):
             )
         except Order.DoesNotExist as ex:
             open_order = Order()
-            open_order.created_date = datetime.datetime.now()
             open_order.customer = current_user
             open_order.save()
 

--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -127,10 +127,6 @@ class Cart(ViewSet):
                 open_order, many=False, context={"request": request}
             )
 
-            product_list = ProductSerializer(
-                products_on_order, many=True, context={"request": request}
-            )
-
             final = {"order": serialized_order.data}
             final["order"]["products"] = product_list.data
             final["order"]["size"] = len(products_on_order)

--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -6,7 +6,6 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.decorators import action
 from bangazonapi.models import Order, Customer, Product, OrderProduct
-from .product import ProductSerializer
 from .order import OrderSerializer
 
 
@@ -121,15 +120,12 @@ class Cart(ViewSet):
         try:
             open_order = Order.objects.get(customer=current_user, payment_type=None)
 
-            products_on_order = Product.objects.filter(lineitems__order=open_order)
-
             serialized_order = OrderSerializer(
                 open_order, many=False, context={"request": request}
             )
 
             final = {"order": serialized_order.data}
-            final["order"]["products"] = product_list.data
-            final["order"]["size"] = len(products_on_order)
+            final["order"]["size"] = len(final["order"]["lineitems"])
 
         except Order.DoesNotExist as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -11,6 +11,12 @@ from bangazonapi.models import Order, Payment, Customer, Product, OrderProduct
 from .product import ProductSerializer
 
 
+class PaymentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Payment
+        fields = ("id", "merchant_name")
+
+
 class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for line items"""
 
@@ -29,6 +35,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
     lineitems = OrderLineItemSerializer(many=True)
+    payment_type = PaymentSerializer()
     total = serializers.SerializerMethodField()
 
     class Meta:

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -38,6 +38,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             "id",
             "url",
             "created_date",
+            "completed_on",
             "payment_type",
             "customer",
             "lineitems",

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -118,7 +118,8 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type_id = request.data["payment_type"]
+        payment = Payment.objects.get(pk=request.data["payment_type"])
+        order.payment_type = payment
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -120,6 +120,7 @@ class Orders(ViewSet):
         order = Order.objects.get(pk=pk, customer=customer)
         payment = Payment.objects.get(pk=request.data["payment_type"])
         order.payment_type = payment
+        order.completed_on = datetime.date.today()
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -265,7 +265,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
When a user clicks on the My Orders nav item, the correct number of rows in the table are created, but no information about the orders is displayed.

When the user clicks Complete Order from the cart view, and then selects a payment type, and then clicks on the Complete Order button on that dialog, the order does not complete. It is expected for the order to be marked as complete so that it shows up in the My Orders view and the cart is emptied.

## Changes

- Added completed on date to order model and changed created date to auto_now
- removed productserializer from cart.py  and removed now unneeded created_date
- Added paymentSerializer to order.py to handle being able to display merchant name in listed orders 
- Added paymenttype = none to open_order in profile.py

## Requests / Responses

Created PUT request to test that order gets completed and shows completion date

**Request**

PUT `/orders/:id` Adds payment to order closing order

```json
{
  "payment_type": 4
}
```

**Response**

HTTP/1.1 204 no content


## Testing

- [ ] reseed data ./seed_data.sh
- [ ] Create PUT request to Complete Order with json body from request (don't forget authorization) TOKEN ending in 90
- [ ] In Bruno/Yaak run GET shopping cart
- [ ] If cart empty run POST Add Item to cart
- [ ] GET shopping cart and grab cart id
- [ ] run PUT request to orders/:id inserting cart id 
- [ ] check database to make sure order was updated as complete


## Related Issues

- Fixes #33 
- Fixes #35 